### PR TITLE
Adds optional inputs with defaults to support multi env deployments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,9 +17,11 @@ inputs:
     default: 'true'
   working_directory:
     description: 'Path to run Poly commands in'
+    required: false
     default: '.'
   commit_path:
     description: "Path given to git add"
+    required: false
     default: '.' 
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,9 @@ inputs:
     description: 'Whether the action should run its own actions/checkout step.'
     required: false
     default: 'true'
+  working_directory:
+    description: 'Path to run Poly commands in'
+    default: '.'
 
 runs:
   using: composite
@@ -25,6 +28,7 @@ runs:
         POLY_API_KEY: ${{ inputs.poly_api_key }}
         POLY_API_BASE_URL: ${{ inputs.poly_api_base_url }}
       run: |
+        cd "${{ inputs.working_directory }}"
         if [ -z "${POLY_API_KEY:-}" ]; then
           echo "poly_api_key is not defined. Did you forget to set it up as a secret or forget to pass it in?"
           exit 1
@@ -41,6 +45,7 @@ runs:
     - name: Poly pre-check
       shell: bash
       run: |
+        cd "${{ inputs.working_directory }}"
         if ! grep -q 'polyapi' requirements.txt; then
           echo "Please add the PolyAPI client to your requirements.txt file."
           exit 1
@@ -63,6 +68,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
+        cd "${{ inputs.working_directory }}"
         pip install --upgrade pip
         pip install -r requirements.txt
 
@@ -70,6 +76,7 @@ runs:
       id: poly_dir
       shell: bash
       run: |
+        cd "${{ inputs.working_directory }}"
         POLY_DIR=$(python -c "import polyapi; import os; print(os.path.dirname(polyapi.__file__))")
         mkdir -p "$POLY_DIR/poly"
         echo "poly_dir=$POLY_DIR" >> $GITHUB_ENV
@@ -89,6 +96,7 @@ runs:
         POLY_API_KEY: ${{ inputs.poly_api_key }}
         POLY_API_BASE_URL: ${{ inputs.poly_api_base_url }}
       run: |
+        cd "${{ inputs.working_directory }}"
         python -m polyapi sync
 
     - name: Cache PolyAPI deployments
@@ -102,6 +110,7 @@ runs:
     - name: Commit deployment receipts
       shell: bash
       run: |
+        cd "${{ inputs.working_directory }}"
         git config --global user.name 'PolyAPI Deployment Bot'
         git config --global user.email 'poly-deployments@polyapi.io'
         git add .

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   poly_api_base_url:
     description: 'The base URL for the deploy target Poly instance.'
     required: true
+  do_checkout:
+    description: 'Whether the action should run its own actions/checkout step.'
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -31,6 +35,7 @@ runs:
         fi
   
     - name: Checkout code
+      if: ${{ inputs.do_checkout == 'true' }}
       uses: actions/checkout@v4
 
     - name: Poly pre-check

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
   working_directory:
     description: 'Path to run Poly commands in'
     default: '.'
+  commit_path:
+    description: "Path given to git add"
+    default: '.' 
 
 runs:
   using: composite
@@ -113,7 +116,7 @@ runs:
         cd "${{ inputs.working_directory }}"
         git config --global user.name 'PolyAPI Deployment Bot'
         git config --global user.email 'poly-deployments@polyapi.io'
-        git add .
+        git add "${{ inputs.commit_path }}" || true
         if ! git diff-index --quiet HEAD; then
           git commit -m "PolyAPI Deployment" --no-verify
         else

--- a/action.yml
+++ b/action.yml
@@ -19,14 +19,18 @@ inputs:
     description: 'Path to run Poly commands in'
     required: false
     default: '.'
-  commit_path:
-    description: "Path given to git add"
-    required: false
-    default: '.' 
 
 runs:
   using: composite
   steps:
+    - name: Validate working_directory
+      shell: bash
+      run: |
+        if [ ! -d "${{ inputs.working_directory }}" ]; then
+          echo "working_directory '${{ inputs.working_directory }}' does not exist or is not a directory."
+          exit 1
+        fi
+
     - name: Check inputs
       shell: bash
       env:
@@ -42,7 +46,7 @@ runs:
           echo "poly_api_base_url is not defined. Did you forget to set it up as a secret or forget to pass it in?"
           exit 1
         fi
-  
+
     - name: Checkout code
       if: ${{ inputs.do_checkout == 'true' }}
       uses: actions/checkout@v4
@@ -118,7 +122,7 @@ runs:
         cd "${{ inputs.working_directory }}"
         git config --global user.name 'PolyAPI Deployment Bot'
         git config --global user.email 'poly-deployments@polyapi.io'
-        git add "${{ inputs.commit_path }}" || true
+        git add .
         if ! git diff-index --quiet HEAD; then
           git commit -m "PolyAPI Deployment" --no-verify
         else


### PR DESCRIPTION
Added the following inputs:
- do_checkout
- working_directory
- commit_path

These inputs are optional with defaults, making this action backwards compatible to all existing glide projects.

Example usage in a multi-env deployment project:
```
      # foo env job
      - uses: polyapi/poly-deployment-action-py@v0.0.6
        with:
          poly_api_key: ${{ secrets.FOO_POLY_API_KEY }}
          poly_api_base_url: ${{ secrets.FOO_POLY_API_BASE_URL }}
          do_checkout: 'false'
          working_directory: foo
          commit_path: '.'

      - name: Sync to latest foo
        run: |
          git config user.email "actions@users.noreply.github.com"
          git config user.name  "PolyAPI Deployment Bot"
          git fetch origin foo
          git reset --hard origin/foo

      # blah env job
      - uses: polyapi/poly-deployment-action-py@v0.0.6
        with:
          poly_api_key: ${{ secrets.BLAH_POLY_API_KEY }}
          poly_api_base_url: ${{ secrets.BLAH_POLY_API_BASE_URL }}
          do_checkout: 'false'
          working_directory: blah
          commit_path: '.'
```